### PR TITLE
HB-4942: Use proper bidding and non-bidding APIs

### DIFF
--- a/Source/VungleAdapterBannerAd.swift
+++ b/Source/VungleAdapterBannerAd.swift
@@ -27,7 +27,9 @@ final class VungleAdapterBannerAd: VungleAdapterAd, PartnerAd {
         let bannerSize = vungleBannerSize(for: request.size)
         
         // If ad already loaded succeed immediately
-        guard !VungleSDK.shared().isAdCached(forPlacementID: request.partnerPlacement, adMarkup: request.adm, with: bannerSize) else {
+        guard !(request.adm == nil && VungleSDK.shared().isAdCached(forPlacementID: request.partnerPlacement, with: bannerSize))
+           && !(request.adm != nil && VungleSDK.shared().isAdCached(forPlacementID: request.partnerPlacement, adMarkup: request.adm, with: bannerSize))
+        else {
             log(.loadSucceeded)
             completion(.success([:]))
             return
@@ -35,7 +37,11 @@ final class VungleAdapterBannerAd: VungleAdapterAd, PartnerAd {
         
         // Start loading
         do {
-            try VungleSDK.shared().loadPlacement(withID: request.partnerPlacement, adMarkup: request.adm, with: bannerSize)
+            if let adm = request.adm {
+                try VungleSDK.shared().loadPlacement(withID: request.partnerPlacement, adMarkup: adm, with: bannerSize)
+            } else {
+                try VungleSDK.shared().loadPlacement(withID: request.partnerPlacement, with: bannerSize)
+            }
         } catch {
             log(.loadFailed(error))
             completion(.failure(error))

--- a/Source/VungleAdapterFullscreenAd.swift
+++ b/Source/VungleAdapterFullscreenAd.swift
@@ -23,7 +23,9 @@ final class VungleAdapterFullscreenAd: VungleAdapterAd, PartnerAd {
         log(.loadStarted)
         
         // If ad already loaded succeed immediately
-        guard !VungleSDK.shared().isAdCached(forPlacementID: request.partnerPlacement, adMarkup: request.adm) else {
+        guard !(request.adm == nil && VungleSDK.shared().isAdCached(forPlacementID: request.partnerPlacement))
+           && !(request.adm != nil && VungleSDK.shared().isAdCached(forPlacementID: request.partnerPlacement, adMarkup: request.adm))
+        else {
             log(.loadSucceeded)
             completion(.success([:]))
             return
@@ -32,7 +34,11 @@ final class VungleAdapterFullscreenAd: VungleAdapterAd, PartnerAd {
         // Start loading
         loadCompletion = completion
         do {
-            try VungleSDK.shared().loadPlacement(withID: request.partnerPlacement, adMarkup: request.adm)
+            if let adm = request.adm {
+                try VungleSDK.shared().loadPlacement(withID: request.partnerPlacement, adMarkup: adm)
+            } else {
+                try VungleSDK.shared().loadPlacement(withID: request.partnerPlacement)
+            }
         } catch {
             log(.loadFailed(error))
             completion(.failure(error))
@@ -51,7 +57,11 @@ final class VungleAdapterFullscreenAd: VungleAdapterAd, PartnerAd {
         
         // Show ad
         do {
-            try VungleSDK.shared().playAd(viewController, options: [:], placementID: request.partnerPlacement)
+            if let adm = request.adm {
+                try VungleSDK.shared().playAd(viewController, options: [:], placementID: request.partnerPlacement, adMarkup: adm)
+            } else {
+                try VungleSDK.shared().playAd(viewController, options: [:], placementID: request.partnerPlacement)
+            }
         } catch {
             log(.showFailed(error))
             completion(.failure(error))


### PR DESCRIPTION
Although some of these methods have the same signature with only one extra/missing parameter, they are defined in different headers (there's a Vungle header for header bidding APIs, and a different one for non-header bidding APIs), and apparently they work differently.

I separated the uses of each set of APIs depending on if an adm is present (bidding) or not (programmatic, non-header bidding)