### PR TITLE
HB-4935: Simplify use of unknown errors in adapters

### DIFF
--- a/Source/VungleAdapter.swift
+++ b/Source/VungleAdapter.swift
@@ -150,9 +150,8 @@ extension VungleAdapter {
     
     /// VungleSDK initialization failure forwarded by router.
     func vungleSDKFailedToInitializeWithError(_ partnerError: Error) {
-        let error = error(.initializationFailureUnknown, error: partnerError)
-        log(.setUpFailed(error))
-        setUpCompletion?(error)
+        log(.setUpFailed(partnerError))
+        setUpCompletion?(partnerError)
         setUpCompletion = nil
     }
 }

--- a/Source/VungleAdapterBannerAd.swift
+++ b/Source/VungleAdapterBannerAd.swift
@@ -112,7 +112,6 @@ extension VungleAdapterBannerAd {
                     }
                 } catch {
                     // Fail to attach vungle view to inlineView container.
-                    let error = self.error(.loadFailureUnknown, error: error)
                     log(.loadFailed(error))
                     loadCompletion?(.failure(error)) ?? log(.loadResultIgnored)
                 }
@@ -121,7 +120,7 @@ extension VungleAdapterBannerAd {
             }
         } else {
             // Report load failure
-            let error = error(.loadFailureUnknown, error: partnerError)
+            let error = partnerError ?? error(.loadFailureUnknown)
             log(.loadFailed(error))
             loadCompletion?(.failure(error)) ?? log(.loadResultIgnored)
             loadCompletion = nil

--- a/Source/VungleAdapterFullscreenAd.swift
+++ b/Source/VungleAdapterFullscreenAd.swift
@@ -87,7 +87,7 @@ extension VungleAdapterFullscreenAd {
             loadCompletion = nil
         } else {
             // Report load failure
-            let error = error(.loadFailureUnknown, error: partnerError)
+            let error = partnerError ?? error(.loadFailureUnknown)
             log(.loadFailed(error))
             loadCompletion?(.failure(error)) ?? log(.loadResultIgnored)
             loadCompletion = nil


### PR DESCRIPTION
https://chartboost.atlassian.net/browse/HB-4935

Partner errors can now be directly used with `PartnerAdLogEvent` and the completion handlers, which will get auto-wrapped within a `HeliumError` with the appropriate `unknown` code, per the work done in https://github.com/ChartBoost/ios-helium-sdk/pull/882.  Also, partners that supply a code can create an error using the `PartnerAd.partnerError(_code:)` method instead.
