### PR TITLE
HB-5025: rename Helium 4.X podspec names and contents to `ChartboostMediation`

### DIFF
--- a/ChartboostMediationAdapterVungle.podspec
+++ b/ChartboostMediationAdapterVungle.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |spec|
   spec.ios.frameworks = ['Foundation', 'UIKit']
   
   # This adapter is compatible with all Chartboost Mediation 4.X versions of the SDK.
-  spec.dependency 'ChartboostMediation', '~> 4.0'
+  spec.dependency 'ChartboostMediationSDK', '~> 4.0'
 
   # Partner network SDK and version that this adapter is certified to work with.
   spec.dependency 'VungleSDK-iOS', '6.12.1'


### PR DESCRIPTION
This repo is not published yet, thus the old podspec file can be removed without calling `pod trunk deprecate`.