### PR TITLE
HB-5214: Guard against integer underflow when mapping errors

### DIFF
--- a/Source/VungleAdapter.swift
+++ b/Source/VungleAdapter.swift
@@ -156,8 +156,13 @@ final class VungleAdapter: PartnerAdapter {
     /// Only implement if the partner SDK provides its own list of error codes that can be mapped to Chartboost Mediation's.
     /// If some case cannot be mapped return `nil` to let Chartboost Mediation choose a default error code.
     func mapSetUpError(_ error: Error) -> ChartboostMediationError.Code? {
-        let code = VungleSDKErrorCode(rawValue: UInt32((error as NSError).code))
-        switch code {
+        guard let errorCode = UInt32(exactly: (error as NSError).code) else {
+            return nil
+        }
+
+        let vungleErrorCode = VungleSDKErrorCode(rawValue: errorCode)
+
+        switch vungleErrorCode {
         case VungleSDKErrorNoAppID:
             return .initializationFailureInvalidCredentials
         case VungleSDKErrorInvalidiOSVersion:
@@ -176,8 +181,13 @@ final class VungleAdapter: PartnerAdapter {
     /// Only implement if the partner SDK provides its own list of error codes that can be mapped to Chartboost Mediation's.
     /// If some case cannot be mapped return `nil` to let Chartboost Mediation choose a default error code.
     func mapLoadError(_ error: Error) -> ChartboostMediationError.Code? {
-        let code = VungleSDKErrorCode(rawValue: UInt32((error as NSError).code))
-        switch code {
+        guard let errorCode = UInt32(exactly: (error as NSError).code) else {
+            return nil
+        }
+
+        let vungleErrorCode = VungleSDKErrorCode(rawValue: errorCode)
+
+        switch vungleErrorCode {
         case VungleSDKErrorInvalidAdTypeForFeedBasedAdExperience:
             return .loadFailureMismatchedAdFormat
         case VungleSDKErrorNoAppID:
@@ -228,8 +238,13 @@ final class VungleAdapter: PartnerAdapter {
     /// Only implement if the partner SDK provides its own list of error codes that can be mapped to Chartboost Mediation's.
     /// If some case cannot be mapped return `nil` to let Chartboost Mediation choose a default error code.
     func mapShowError(_ error: Error) -> ChartboostMediationError.Code? {
-        let code = VungleSDKErrorCode(rawValue: UInt32((error as NSError).code))
-        switch code {
+        guard let errorCode = UInt32(exactly: (error as NSError).code) else {
+            return nil
+        }
+
+        let vungleErrorCode = VungleSDKErrorCode(rawValue: errorCode)
+        
+        switch vungleErrorCode {
         case VungleSDKErrorCannotPlayAdAlreadyPlaying:
             return .showFailureShowInProgress
         case VungleSDKErrorCannotPlayAdWaiting:


### PR DESCRIPTION
I was getting an SSL error with the error code `-1200`, which was causing a crash due to integer underflow. This change will protect against both underflow and overflow. This change has been made to all adapters that convert to `Int32` or `UInt32`.