### PR TITLE
HB-5230: Remove lazy creation of the inline view from the Vungle adapter

### DIFF
--- a/Source/VungleAdapterBannerAd.swift
+++ b/Source/VungleAdapterBannerAd.swift
@@ -12,7 +12,7 @@ final class VungleAdapterBannerAd: VungleAdapterAd, PartnerAd {
     
     /// The partner ad view to display inline. E.g. a banner view.
     /// Should be nil for full-screen ads.
-    lazy var inlineView: UIView? = UIView()
+    var inlineView: UIView? = UIView()
     
     /// Loads an ad.
     /// - parameter viewController: The view controller on which the ad will be presented on. Needed on load for some banners.


### PR DESCRIPTION
 In [AdBidFulfiller](https://github.com/ChartBoost/ios-helium-sdk/blob/2e103ae17a4ac4176c0bda5ad662decc0104172c/HeliumSdk/HeliumSdk/HeliumSdk/Ad%20Loading/AdBidFulfiller.swift#L138), we’re checking `ad.inlineView == nil`. When that check occurs, since Vungle's `inlineView` is lazy, it creates the view, and since that code is running on a background thread, we end up accessing the UIKit API on a background thread. This doesn't seem to fix the issue of Vungle banners not rendering, but we should fix it anyway.

@daniel-barros Can you confirm this fix looks good? Alternatively, we could move the view initialization into `load`, if we did want lazy loading of the view.