### PR TITLE
HB-5241: Fix MREC integration

### DIFF
--- a/Source/VungleAdapterBannerAd.swift
+++ b/Source/VungleAdapterBannerAd.swift
@@ -22,8 +22,15 @@ final class VungleAdapterBannerAd: VungleAdapterAd, PartnerAd {
         
         // If ad already loaded succeed immediately
         guard !adIsCachedByVungle else {
-            log(.loadSucceeded)
-            completion(.success([:]))
+            // Attach vungle view to the inlineView container.
+            do {
+                try addVungleAdToContainer()
+                log(.loadSucceeded)
+                completion(.success([:]))
+            } catch {
+                log(.loadFailed(error))
+                completion(.failure(error))
+            }
             return
         }
         


### PR DESCRIPTION
Fix container view size for MREC.
Fix `isAdCached`, `loadPlacement` methods for MREC. Note MREC requires a different set of methods than banner, and MREC does not have an associated VungleAdSize, which applies only to Vungle banners.
Fix `addAdView` call for programmatic loads.
Fix loading of already cached ads, by attaching them to the container.