### PR TITLE
Explicitly call out the namespace to avoid future naming conflicts

### DIFF
--- a/Source/VungleAdapterBannerAd.swift
+++ b/Source/VungleAdapterBannerAd.swift
@@ -143,7 +143,7 @@ extension VungleAdapterBannerAd: VungleBannerDelegate {
 
 // MARK: - Helpers
 extension VungleAdapterBannerAd {
-    private func fixedBannerSize(for requestedSize: CGSize) -> (size: CGSize, partnerSize: BannerSize)? {
+    private func fixedBannerSize(for requestedSize: CGSize) -> (size: CGSize, partnerSize: VungleAdsSDK.BannerSize)? {
         let sizes: [(size: CGSize, partnerSize: BannerSize)] = [
             (size: IABLeaderboardAdSize, partnerSize: .leaderboard),
             (size: IABMediumAdSize, partnerSize: .mrec),


### PR DESCRIPTION
Need to explicitly namespace `VungleAdsSDK.BannerSize` because Mediation 5.0 will have a `BannerSize` as well, which is currently `CHBHBannerSize`.