### PR TITLE
HB-5890: namespace `BannerSize` to be more specific

### DIFF
--- a/Source/VungleAdapterBannerAd.swift
+++ b/Source/VungleAdapterBannerAd.swift
@@ -144,7 +144,7 @@ extension VungleAdapterBannerAd: VungleBannerDelegate {
 // MARK: - Helpers
 extension VungleAdapterBannerAd {
     private func fixedBannerSize(for requestedSize: CGSize) -> (size: CGSize, partnerSize: VungleAdsSDK.BannerSize)? {
-        let sizes: [(size: CGSize, partnerSize: BannerSize)] = [
+        let sizes: [(size: CGSize, partnerSize: VungleAdsSDK.BannerSize)] = [
             (size: IABLeaderboardAdSize, partnerSize: .leaderboard),
             (size: IABMediumAdSize, partnerSize: .mrec),
             (size: IABStandardAdSize, partnerSize: .regular)


### PR DESCRIPTION
`VungleAdsSDK.BannerSize` vs `ChartboostMediation.BannerSize`