### PR TITLE
HB-7647: Configuration class rework

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -25,7 +25,7 @@ jobs:
   create-release-branch:
     runs-on: macos-14
     steps:
-      - uses: chartboost/chartboost-mediation-ios-actions/create-adapter-release-branch@v1
+      - uses: chartboost/chartboost-mediation-ios-actions/create-adapter-release-branch@v2
         with:
           adapter-version: ${{ inputs.adapter-version || github.event.client_payload.adapter-version }}
           partner-version: ${{ inputs.partner-version || github.event.client_payload.partner-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,6 @@ jobs:
   release-adapter:
     runs-on: macos-14
     steps:
-      - uses: chartboost/chartboost-mediation-ios-actions/release-adapter@v1
+      - uses: chartboost/chartboost-mediation-ios-actions/release-adapter@v2
         with:
           allow-warnings: true

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -12,6 +12,6 @@ jobs:
   validate-podspec:
     runs-on: macos-14
     steps:
-      - uses: chartboost/chartboost-mediation-ios-actions/adapter-smoke-test@v1
+      - uses: chartboost/chartboost-mediation-ios-actions/adapter-smoke-test@v2
         with:
           allow-warnings: true

--- a/Source/VungleAdapter.swift
+++ b/Source/VungleAdapter.swift
@@ -13,19 +13,27 @@ final class VungleAdapter: PartnerAdapter {
     private let COPPA_KEY = "com.chartboost.adapter.vungle.coppa"
 
     /// The version of the partner SDK.
-    let partnerSDKVersion = VungleAds.sdkVersion
-    
+    var partnerSDKVersion: String {
+        VungleAdapterConfiguration.partnerSDKVersion
+    }
+
     /// The version of the adapter.
     /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
     /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
-    let adapterVersion = "4.7.3.0.0"
-    
+    var adapterVersion: String {
+        VungleAdapterConfiguration.adapterVersion
+    }
+
     /// The partner's unique identifier.
-    let partnerID = "vungle"
-    
+    var partnerID: String {
+        VungleAdapterConfiguration.partnerID
+    }
+
     /// The human-friendly partner name.
-    let partnerDisplayName = "Vungle"
-    
+    var partnerDisplayName: String {
+        VungleAdapterConfiguration.partnerDisplayName
+    }
+
     /// The designated initializer for the adapter.
     /// Chartboost Mediation SDK will use this constructor to create instances of conforming types.
     /// - parameter storage: An object that exposes storage managed by the Chartboost Mediation SDK to the adapter.

--- a/Source/VungleAdapterConfiguration.swift
+++ b/Source/VungleAdapterConfiguration.swift
@@ -1,4 +1,4 @@
-// Copyright 2023-2024 Chartboost, Inc.
+// Copyright 2022-2024 Chartboost, Inc.
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.

--- a/Source/VungleAdapterConfiguration.swift
+++ b/Source/VungleAdapterConfiguration.swift
@@ -1,0 +1,27 @@
+// Copyright 2023-2024 Chartboost, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+
+import Foundation
+import VungleAdsSDK
+
+/// A list of externally configurable properties pertaining to the partner SDK that can be retrieved and set by publishers.
+@objc public class VungleAdapterConfiguration: NSObject {
+
+    /// The version of the partner SDK.
+    @objc static var partnerSDKVersion: String {
+        VungleAds.sdkVersion
+    }
+
+    /// The version of the adapter.
+    /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
+    /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
+    @objc static let adapterVersion = "4.7.3.0.0"
+
+    /// The partner's unique identifier.
+    @objc static let partnerID = "vungle"
+
+    /// The human-friendly partner name.
+    @objc static let partnerDisplayName = "Vungle"
+}

--- a/Source/VungleAdapterConfiguration.swift
+++ b/Source/VungleAdapterConfiguration.swift
@@ -10,18 +10,18 @@ import VungleAdsSDK
 @objc public class VungleAdapterConfiguration: NSObject {
 
     /// The version of the partner SDK.
-    @objc static var partnerSDKVersion: String {
+    @objc public static var partnerSDKVersion: String {
         VungleAds.sdkVersion
     }
 
     /// The version of the adapter.
     /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
     /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
-    @objc static let adapterVersion = "4.7.3.0.0"
+    @objc public static let adapterVersion = "4.7.3.0.0"
 
     /// The partner's unique identifier.
-    @objc static let partnerID = "vungle"
+    @objc public static let partnerID = "vungle"
 
     /// The human-friendly partner name.
-    @objc static let partnerDisplayName = "Vungle"
+    @objc public static let partnerDisplayName = "Vungle"
 }


### PR DESCRIPTION
Move module property definitions to the public Configuration class to expose them to pubs and Unity. Add missing configuration options for parity with Android.