### PR TITLE
HB-7607: Refactor `fixedBannerSize(for: BannerSize?)`

### DIFF
--- a/Source/VungleAdapterBannerAd.swift
+++ b/Source/VungleAdapterBannerAd.swift
@@ -132,23 +132,27 @@ extension VungleAdapterBannerAd: VungleBannerDelegate {
 // MARK: - Helpers
 extension VungleAdapterBannerAd {
     private func fixedBannerSize(for requestedSize: ChartboostMediationSDK.BannerSize?) -> (size: CGSize, partnerSize: VungleAdsSDK.BannerSize)? {
+        // Return a default value if no size is specified.
         guard let requestedSize else {
-            return (IABStandardAdSize, .regular)
+            return (BannerSize.standard.size, .regular)
         }
-        let sizes: [(size: CGSize, partnerSize: VungleAdsSDK.BannerSize)] = [
-            (size: IABLeaderboardAdSize, partnerSize: .leaderboard),
-            (size: IABMediumAdSize, partnerSize: .mrec),
-            (size: IABStandardAdSize, partnerSize: .regular)
-        ]
-        // Find the largest size that can fit in the requested size.
-        for (size, partnerSize) in sizes {
-            // If height is 0, the pub has requested an ad of any height, so only the width matters.
-            if requestedSize.size.width >= size.width &&
-                (size.height == 0 || requestedSize.size.height >= size.height) {
-                return (size, partnerSize)
+        // If we can find a size that fits, return that.
+        if let size = BannerSize.largestStandardFixedSizeThatFits(in: requestedSize) {
+            switch size {
+            case .standard:
+                return (BannerSize.standard.size, .regular)
+            case .medium:
+                return (BannerSize.medium.size, .mrec)
+            case .leaderboard:
+                return (BannerSize.leaderboard.size, .leaderboard)
+            default:
+                // largestStandardFixedSizeThatFits currently only returns .standard, .medium, or .leaderboard,
+                // but if that changes then just default to .standard until this code gets updated.
+                return (BannerSize.standard.size, .regular)
             }
+        } else {
+            // largestStandardFixedSizeThatFits has returned nil to indicate it couldn't find a fit.
+            return nil
         }
-        // The requested size cannot fit any fixed size banners.
-        return nil
     }
 }


### PR DESCRIPTION
Most of the adapters have a simpler version of `fixedBannerSize(for: BannerSize?)` that returns `CGSize?` but there are a few others like this one that return a tuple of `CGSize` and a partner-specific type. Before I update all of those I want to know if there's anything I should do differently than I've done here.