### PR TITLE
HB-7607: Replace duplicated code with call to helper method

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -25,7 +25,7 @@ jobs:
   create-release-branch:
     runs-on: macos-14
     steps:
-      - uses: chartboost/chartboost-mediation-ios-actions/create-adapter-release-branch@v1
+      - uses: chartboost/chartboost-mediation-ios-actions/create-adapter-release-branch@v2
         with:
           adapter-version: ${{ inputs.adapter-version || github.event.client_payload.adapter-version }}
           partner-version: ${{ inputs.partner-version || github.event.client_payload.partner-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,6 @@ jobs:
   release-adapter:
     runs-on: macos-14
     steps:
-      - uses: chartboost/chartboost-mediation-ios-actions/release-adapter@v1
+      - uses: chartboost/chartboost-mediation-ios-actions/release-adapter@v2
         with:
           allow-warnings: true

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -12,6 +12,6 @@ jobs:
   validate-podspec:
     runs-on: macos-14
     steps:
-      - uses: chartboost/chartboost-mediation-ios-actions/adapter-smoke-test@v1
+      - uses: chartboost/chartboost-mediation-ios-actions/adapter-smoke-test@v2
         with:
           allow-warnings: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 Note the first digit of every adapter version corresponds to the major version of the Chartboost Mediation SDK compatible with that adapter. 
 Adapters are compatible with any Chartboost Mediation SDK version within that major version.
 
+### 5.7.3.0.0
+- The minimum deployment target compatible with this adapter is now iOS 13.
+- This version of the adapter has been certified with ChartboostMediationSDK 5.0.0.
+- This version of the adapter has been certified with VungleAds 7.3.0.
+
 ### 4.7.3.0.0
 - This version of the adapter has been certified with VungleAds 7.3.0. Minimum deployment target is now 12.0.
 

--- a/ChartboostMediationAdapterVungle.podspec
+++ b/ChartboostMediationAdapterVungle.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name        = 'ChartboostMediationAdapterVungle'
-  spec.version     = '4.7.3.0.0'
+  spec.version     = '5.7.3.0.0'
   spec.license     = { :type => 'MIT', :file => 'LICENSE.md' }
   spec.homepage    = 'https://github.com/ChartBoost/chartboost-mediation-ios-adapter-vungle'
   spec.authors     = { 'Chartboost' => 'https://www.chartboost.com/' }
@@ -20,8 +20,8 @@ Pod::Spec.new do |spec|
   # System frameworks used
   spec.ios.frameworks = ['Foundation', 'UIKit']
   
-  # This adapter is compatible with all Chartboost Mediation 4.X versions of the SDK.
-  spec.dependency 'ChartboostMediationSDK', '~> 4.0'
+  # This adapter is compatible with all Chartboost Mediation 5.X versions of the SDK.
+  spec.dependency 'ChartboostMediationSDK', '~> 5.0'
 
   # Partner network SDK and version that this adapter is certified to work with.
   spec.dependency 'VungleAds', '~> 7.3.0'

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ The Chartboost Mediation Vungle adapter mediates Vungle via the Chartboost Media
 
 | Plugin | Version |
 | ------ | ------ |
-| Chartboost Mediation SDK | 4.0.0+ |
+| Chartboost Mediation SDK | 5.0.0+ |
 | Cocoapods | 1.11.3+ |
 | iOS | 13.0+ |
-| Xcode | 14.1+ |
+| Xcode | 15.0+ |
 
 ## Integration
 

--- a/Source/VungleAdapter.swift
+++ b/Source/VungleAdapter.swift
@@ -116,7 +116,7 @@ final class VungleAdapter: PartnerAdapter {
     func makeAd(request: PartnerAdLoadRequest, delegate: PartnerAdDelegate) throws -> PartnerAd {
         // As of 7.0.0, Vungle now supports multiple loads of the same placement
         switch request.format {
-        case PartnerAdFormats.banner, PartnerAdFormats.adaptiveBanner:
+        case PartnerAdFormats.banner:
             return VungleAdapterBannerAd(adapter: self, request: request, delegate: delegate)
         case PartnerAdFormats.interstitial:
             return VungleAdapterInterstitialAd(adapter: self, request: request, delegate: delegate)

--- a/Source/VungleAdapter.swift
+++ b/Source/VungleAdapter.swift
@@ -11,19 +11,27 @@ import VungleAdsSDK
 final class VungleAdapter: PartnerAdapter {
 
     /// The version of the partner SDK.
-    let partnerSDKVersion = VungleAds.sdkVersion
-    
+    var partnerSDKVersion: String {
+        VungleAdapterConfiguration.partnerSDKVersion
+    }
+
     /// The version of the adapter.
     /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
     /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
-    let adapterVersion = "4.7.3.0.0"
-    
+    var adapterVersion: String {
+        VungleAdapterConfiguration.adapterVersion
+    }
+
     /// The partner's unique identifier.
-    let partnerID = "vungle"
-    
+    var partnerID: String {
+        VungleAdapterConfiguration.partnerID
+    }
+
     /// The human-friendly partner name.
-    let partnerDisplayName = "Vungle"
-    
+    var partnerDisplayName: String {
+        VungleAdapterConfiguration.partnerDisplayName
+    }
+
     /// The designated initializer for the adapter.
     /// Chartboost Mediation SDK will use this constructor to create instances of conforming types.
     /// - parameter storage: An object that exposes storage managed by the Chartboost Mediation SDK to the adapter.

--- a/Source/VungleAdapter.swift
+++ b/Source/VungleAdapter.swift
@@ -106,18 +106,31 @@ final class VungleAdapter: PartnerAdapter {
         log(.privacyUpdated(setting: "COPPA Status", value: isChildDirected))
     }
     
+    /// Creates a new banner ad object in charge of communicating with a single partner SDK ad instance.
+    /// Chartboost Mediation SDK calls this method to create a new ad for each new load request. Ad instances are never reused.
+    /// Chartboost Mediation SDK takes care of storing and disposing of ad instances so you don't need to.
+    /// ``PartnerAd/invalidate()`` is called on ads before disposing of them in case partners need to perform any custom logic before the
+    /// object gets destroyed.
+    /// If, for some reason, a new ad cannot be provided, an error should be thrown.
+    /// Chartboost Mediation SDK will always call this method from the main thread.
+    /// - parameter request: Information about the ad load request.
+    /// - parameter delegate: The delegate that will receive ad life-cycle notifications.
+    func makeBannerAd(request: PartnerAdLoadRequest, delegate: PartnerAdDelegate) throws -> PartnerBannerAd {
+        // This partner supports multiple loads for the same partner placement.
+        VungleAdapterBannerAd(adapter: self, request: request, delegate: delegate)
+    }
+
     /// Creates a new ad object in charge of communicating with a single partner SDK ad instance.
     /// Chartboost Mediation SDK calls this method to create a new ad for each new load request. Ad instances are never reused.
     /// Chartboost Mediation SDK takes care of storing and disposing of ad instances so you don't need to.
-    /// `invalidate()` is called on ads before disposing of them in case partners need to perform any custom logic before the object gets destroyed.
+    /// ``PartnerAd/invalidate()`` is called on ads before disposing of them in case partners need to perform any custom logic before the
+    /// object gets destroyed.
     /// If, for some reason, a new ad cannot be provided, an error should be thrown.
     /// - parameter request: Information about the ad load request.
     /// - parameter delegate: The delegate that will receive ad life-cycle notifications.
-    func makeAd(request: PartnerAdLoadRequest, delegate: PartnerAdDelegate) throws -> PartnerAd {
-        // As of 7.0.0, Vungle now supports multiple loads of the same placement
+    func makeFullscreenAd(request: PartnerAdLoadRequest, delegate: PartnerAdDelegate) throws -> PartnerFullscreenAd {
+        // This partner supports multiple loads for the same partner placement.
         switch request.format {
-        case PartnerAdFormats.banner:
-            return VungleAdapterBannerAd(adapter: self, request: request, delegate: delegate)
         case PartnerAdFormats.interstitial:
             return VungleAdapterInterstitialAd(adapter: self, request: request, delegate: delegate)
         case PartnerAdFormats.rewarded, PartnerAdFormats.rewardedInterstitial:

--- a/Source/VungleAdapter.swift
+++ b/Source/VungleAdapter.swift
@@ -89,7 +89,10 @@ final class VungleAdapter: PartnerAdapter {
     func setConsents(_ consents: [ConsentKey: ConsentValue], modifiedKeys: Set<ConsentKey>) {
         // GDPR
         // See https://support.vungle.com/hc/en-us/articles/360048572411
-        if modifiedKeys.contains(partnerID) || modifiedKeys.contains(ConsentKeys.gdprConsentGiven) {
+        // Ignore if the consent status has been directly set by publisher via the configuration class.
+        if !VungleAdapterConfiguration.isGDPRStatusOverriden
+            && (modifiedKeys.contains(partnerID) || modifiedKeys.contains(ConsentKeys.gdprConsentGiven))
+        {
             let consent = consents[partnerID] ?? consents[ConsentKeys.gdprConsentGiven]
             switch consent {
             case ConsentValues.granted:
@@ -105,7 +108,8 @@ final class VungleAdapter: PartnerAdapter {
 
         // CCPA
         // See https://support.vungle.com/hc/en-us/articles/360048572411
-        if modifiedKeys.contains(ConsentKeys.ccpaOptIn) {
+        // Ignore if the consent status has been directly set by publisher via the configuration class.
+        if !VungleAdapterConfiguration.isCCPAStatusOverriden && modifiedKeys.contains(ConsentKeys.ccpaOptIn) {
             switch consents[ConsentKeys.ccpaOptIn] {
             case ConsentValues.granted:
                 VunglePrivacySettings.setCCPAStatus(true)

--- a/Source/VungleAdapter.swift
+++ b/Source/VungleAdapter.swift
@@ -10,8 +10,6 @@ import VungleAdsSDK
 /// The Chartboost Mediation Vungle adapter.
 final class VungleAdapter: PartnerAdapter {
 
-    private let COPPA_KEY = "com.chartboost.adapter.vungle.coppa"
-
     /// The version of the partner SDK.
     let partnerSDKVersion = VungleAds.sdkVersion
     
@@ -47,10 +45,12 @@ final class VungleAdapter: PartnerAdapter {
             return
         }
         
+        // Apply initial consents
+        setConsents(configuration.consents, modifiedKeys: Set(configuration.consents.keys))
         // Apply saved COPPA setting before init, as suggested in documentation
         // https://support.vungle.com/hc/en-us/articles/360048572411#recommendations-for-using-vungle-s-coppa-compliance-tools-0-6
-        let savedCOPPASetting = UserDefaults.standard.bool(forKey: COPPA_KEY)
-        VunglePrivacySettings.setCOPPAStatus(savedCOPPASetting)
+        setIsUserUnderage(configuration.isUserUnderage)
+
         // Initialize Vungle
         VungleAds.initWithAppId(appID) { [weak self] initError in
             guard let self = self else { return }
@@ -75,37 +75,50 @@ final class VungleAdapter: PartnerAdapter {
         completion(.success(["bid_token": bidToken]))
     }
     
-    /// Indicates if GDPR applies or not and the user's GDPR consent status.
-    /// - parameter applies: `true` if GDPR applies, `false` if not, `nil` if the publisher has not provided this information.
-    /// - parameter status: One of the `GDPRConsentStatus` values depending on the user's preference.
-    func setGDPR(applies: Bool?, status: GDPRConsentStatus) {
+    /// Indicates that the user consent has changed.
+    /// - parameter consents: The new consents value, including both modified and unmodified consents.
+    /// - parameter modifiedKeys: A set containing all the keys that changed.
+    func setConsents(_ consents: [ConsentKey: ConsentValue], modifiedKeys: Set<ConsentKey>) {
+        // GDPR
         // See https://support.vungle.com/hc/en-us/articles/360048572411
-        if applies == true, status != .unknown {
-            let gdprStatus = status == .granted ? true : false
-            VunglePrivacySettings.setGDPRStatus(gdprStatus)
-            log(.privacyUpdated(setting: "GDPR Status", value: gdprStatus))
+        if modifiedKeys.contains(partnerID) || modifiedKeys.contains(ConsentKeys.gdprConsentGiven) {
+            let consent = consents[partnerID] ?? consents[ConsentKeys.gdprConsentGiven]
+            switch consent {
+            case ConsentValues.granted:
+                VunglePrivacySettings.setGDPRStatus(true)
+                log(.privacyUpdated(setting: "GDPR Status", value: true))
+            case ConsentValues.denied:
+                VunglePrivacySettings.setGDPRStatus(false)
+                log(.privacyUpdated(setting: "GDPR Status", value: false))
+            default:
+                break   // do nothing
+            }
+        }
+
+        // CCPA
+        // See https://support.vungle.com/hc/en-us/articles/360048572411
+        if modifiedKeys.contains(ConsentKeys.ccpaOptIn) {
+            switch consents[ConsentKeys.ccpaOptIn] {
+            case ConsentValues.granted:
+                VunglePrivacySettings.setCCPAStatus(true)
+                log(.privacyUpdated(setting: "CCPA Status", value: true))
+            case ConsentValues.denied:
+                VunglePrivacySettings.setCCPAStatus(false)
+                log(.privacyUpdated(setting: "CCPA Status", value: false))
+            default:
+                break   // do nothing
+            }
         }
     }
-    
-    /// Indicates the CCPA status both as a boolean and as an IAB US privacy string.
-    /// - parameter hasGivenConsent: A boolean indicating if the user has given consent.
-    /// - parameter privacyString: An IAB-compliant string indicating the CCPA status.
-    func setCCPA(hasGivenConsent: Bool, privacyString: String) {
+
+    /// Indicates that the user is underage signal has changed.
+    /// - parameter isUserUnderage: `true` if the user is underage as determined by the publisher, `false` otherwise.
+    func setIsUserUnderage(_ isUserUnderage: Bool) {
         // See https://support.vungle.com/hc/en-us/articles/360048572411
-        VunglePrivacySettings.setCCPAStatus(hasGivenConsent)
-        log(.privacyUpdated(setting: "CCPA Status", value: hasGivenConsent))
+        VunglePrivacySettings.setCOPPAStatus(isUserUnderage)
+        log(.privacyUpdated(setting: "COPPA Status", value: isUserUnderage))
     }
-    
-    /// Indicates if the user is subject to COPPA or not.
-    /// - parameter isChildDirected: `true` if the user is subject to COPPA, `false` otherwise.
-    func setCOPPA(isChildDirected: Bool) {
-        // See https://support.vungle.com/hc/en-us/articles/360048572411
-        VunglePrivacySettings.setCOPPAStatus(isChildDirected)
-        // Save new value so it can be applied prior to init
-        UserDefaults.standard.set(isChildDirected, forKey: COPPA_KEY)
-        log(.privacyUpdated(setting: "COPPA Status", value: isChildDirected))
-    }
-    
+
     /// Creates a new banner ad object in charge of communicating with a single partner SDK ad instance.
     /// Chartboost Mediation SDK calls this method to create a new ad for each new load request. Ad instances are never reused.
     /// Chartboost Mediation SDK takes care of storing and disposing of ad instances so you don't need to.

--- a/Source/VungleAdapterAd.swift
+++ b/Source/VungleAdapterAd.swift
@@ -18,11 +18,13 @@ class VungleAdapterAd: NSObject {
     var details: PartnerDetails = [:]
 
     /// The ad load request associated to the ad.
-    /// It should be the one provided on `PartnerAdapter.makeAd(request:delegate:)`.
+    /// It should be the one provided on ``PartnerAdapter/makeBannerAd(request:delegate:)``
+    /// or ``PartnerAdapter/makeFullscreenAd(request:delegate:)``.
     let request: PartnerAdLoadRequest
     
     /// The partner ad delegate to send ad life-cycle events to.
-    /// It should be the one provided on `PartnerAdapter.makeAd(request:delegate:)`.
+    /// It should be the one provided on ``PartnerAdapter/makeBannerAd(request:delegate:)``
+    /// or ``PartnerAdapter/makeFullscreenAd(request:delegate:)``.
     weak var delegate: PartnerAdDelegate?
         
     /// The completion for the ongoing load operation.

--- a/Source/VungleAdapterAd.swift
+++ b/Source/VungleAdapterAd.swift
@@ -14,6 +14,9 @@ class VungleAdapterAd: NSObject {
     /// The partner adapter that created this ad.
     let adapter: PartnerAdapter
     
+    /// Extra ad information provided by the partner.
+    var details: PartnerDetails = [:]
+
     /// The ad load request associated to the ad.
     /// It should be the one provided on `PartnerAdapter.makeAd(request:delegate:)`.
     let request: PartnerAdLoadRequest
@@ -23,10 +26,10 @@ class VungleAdapterAd: NSObject {
     weak var delegate: PartnerAdDelegate?
         
     /// The completion for the ongoing load operation.
-    var loadCompletion: ((Result<PartnerEventDetails, Error>) -> Void)?
+    var loadCompletion: ((Result<PartnerDetails, Error>) -> Void)?
     
     /// The completion for the ongoing show operation.
-    var showCompletion: ((Result<PartnerEventDetails, Error>) -> Void)?
+    var showCompletion: ((Result<PartnerDetails, Error>) -> Void)?
     
     init(adapter: PartnerAdapter, request: PartnerAdLoadRequest, delegate: PartnerAdDelegate) {
         self.adapter = adapter

--- a/Source/VungleAdapterBannerAd.swift
+++ b/Source/VungleAdapterBannerAd.swift
@@ -17,13 +17,17 @@ final class VungleAdapterBannerAd: VungleAdapterAd, PartnerAd {
     /// Should be nil for full-screen ads.
     var inlineView: UIView? = UIView()
 
+    /// The loaded partner ad banner size.
+    /// Should be `nil` for full-screen ads.
+    var bannerSize: PartnerBannerSize?
+
     /// Indicates if the Vungle banner was displayed with a successful call to Vungle SDK's `addAdView`.
     private var adWasDisplayed = false
 
     /// Loads an ad.
     /// - parameter viewController: The view controller on which the ad will be presented on. Needed on load for some banners.
     /// - parameter completion: Closure to be performed once the ad has been loaded.
-    func load(with viewController: UIViewController?, completion: @escaping (Result<PartnerEventDetails, Error>) -> Void) {
+    func load(with viewController: UIViewController?, completion: @escaping (Result<PartnerDetails, Error>) -> Void) {
         log(.loadStarted)
         loadCompletion = completion
 
@@ -45,7 +49,7 @@ final class VungleAdapterBannerAd: VungleAdapterAd, PartnerAd {
     /// It will never get called for banner ads. You may leave the implementation blank for that ad format.
     /// - parameter viewController: The view controller on which the ad will be presented on.
     /// - parameter completion: Closure to be performed once the ad has been shown.
-    func show(with viewController: UIViewController, completion: @escaping (Result<PartnerEventDetails, Error>) -> Void) {
+    func show(with viewController: UIViewController, completion: @escaping (Result<PartnerDetails, Error>) -> Void) {
         /// NO-OP
     }
 }
@@ -85,12 +89,9 @@ extension VungleAdapterBannerAd: VungleBannerDelegate {
         // All checks passed
         log(.loadSucceeded)
 
-        let partnerDetails = [
-            "bannerWidth": "\(size.width)",
-            "bannerHeight": "\(size.height)",
-            "bannerType": "0" // Fixed banner
-        ]
-        loadCompletion?(.success(partnerDetails)) ?? log(.loadResultIgnored)
+        bannerSize = PartnerBannerSize(size: size, type: .fixed)
+        
+        loadCompletion?(.success([:])) ?? log(.loadResultIgnored)
         loadCompletion = nil
 
         // View must be set to the same size as the ad

--- a/Source/VungleAdapterBannerAd.swift
+++ b/Source/VungleAdapterBannerAd.swift
@@ -66,9 +66,9 @@ extension VungleAdapterBannerAd: VungleBannerDelegate {
             return
         }
 
-        // Fail if inlineView container is unavailable. This should never happen since it is set on load.
+        // Fail if the banner container is unavailable. This should never happen since it is set on load.
         guard let view, let size else {
-            let error = error(.loadFailureNoInlineView, description: "Vungle adapter inlineView is nil.")
+            let error = error(.loadFailureNoBannerView, description: "Vungle adapter bannerView is nil.")
             log(.loadFailed(error))
             loadCompletion?(.failure(error)) ?? log(.loadResultIgnored)
             loadCompletion = nil

--- a/Source/VungleAdapterBannerAd.swift
+++ b/Source/VungleAdapterBannerAd.swift
@@ -132,23 +132,27 @@ extension VungleAdapterBannerAd: VungleBannerDelegate {
 // MARK: - Helpers
 extension VungleAdapterBannerAd {
     private func fixedBannerSize(for requestedSize: ChartboostMediationSDK.BannerSize?) -> (size: CGSize, partnerSize: VungleAdsSDK.BannerSize)? {
+        // Return a default value if no size is specified.
         guard let requestedSize else {
-            return (IABStandardAdSize, .regular)
+            return (BannerSize.standard.size, .regular)
         }
-        let sizes: [(size: CGSize, partnerSize: VungleAdsSDK.BannerSize)] = [
-            (size: IABLeaderboardAdSize, partnerSize: .leaderboard),
-            (size: IABMediumAdSize, partnerSize: .mrec),
-            (size: IABStandardAdSize, partnerSize: .regular)
-        ]
-        // Find the largest size that can fit in the requested size.
-        for (size, partnerSize) in sizes {
-            // If height is 0, the pub has requested an ad of any height, so only the width matters.
-            if requestedSize.size.width >= size.width &&
-                (size.height == 0 || requestedSize.size.height >= size.height) {
-                return (size, partnerSize)
+        // If we can find a size that fits, return that.
+        if let size = BannerSize.largestStandardFixedSizeThatFits(in: requestedSize) {
+            switch size {
+            case .standard:
+                return (BannerSize.standard.size, .regular)
+            case .medium:
+                return (BannerSize.medium.size, .mrec)
+            case .leaderboard:
+                return (BannerSize.leaderboard.size, .leaderboard)
+            default:
+                // largestStandardFixedSizeThatFits currently only returns .standard, .medium, or .leaderboard,
+                // but if that changes then just default to .standard until this code gets updated.
+                return (BannerSize.standard.size, .regular)
             }
+        } else {
+            // largestStandardFixedSizeThatFits has returned nil to indicate it couldn't find a fit.
+            return nil
         }
-        // The requested size cannot fit any fixed size banners.
-        return nil
     }
 }

--- a/Source/VungleAdapterConfiguration.swift
+++ b/Source/VungleAdapterConfiguration.swift
@@ -1,0 +1,27 @@
+// Copyright 2022-2024 Chartboost, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+
+import Foundation
+import VungleAdsSDK
+
+/// A list of externally configurable properties pertaining to the partner SDK that can be retrieved and set by publishers.
+@objc public class VungleAdapterConfiguration: NSObject {
+
+    /// The version of the partner SDK.
+    @objc public static var partnerSDKVersion: String {
+        VungleAds.sdkVersion
+    }
+
+    /// The version of the adapter.
+    /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
+    /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
+    @objc public static let adapterVersion = "4.7.3.0.0"
+
+    /// The partner's unique identifier.
+    @objc public static let partnerID = "vungle"
+
+    /// The human-friendly partner name.
+    @objc public static let partnerDisplayName = "Vungle"
+}

--- a/Source/VungleAdapterConfiguration.swift
+++ b/Source/VungleAdapterConfiguration.swift
@@ -4,6 +4,7 @@
 // license that can be found in the LICENSE file.
 
 import Foundation
+import os.log
 import VungleAdsSDK
 
 /// A list of externally configurable properties pertaining to the partner SDK that can be retrieved and set by publishers.
@@ -24,4 +25,28 @@ import VungleAdsSDK
 
     /// The human-friendly partner name.
     @objc public static let partnerDisplayName = "Vungle"
+
+    /// Use to manually set the consent status on the Pangle SDK.
+    /// This is generally unnecessary as the Mediation SDK will set the consent status automatically based on the latest consent info.
+    @objc public static func setGDPRStatusOverride(_ status: Bool) {
+        isGDPRStatusOverriden = true
+        VunglePrivacySettings.setGDPRStatus(status)
+        os_log(.info, log: log, "Vungle SDK GDPR status override set to %{public}s", "\(status)")
+    }
+
+    /// Use to manually set the consent status on the Pangle SDK.
+    /// This is generally unnecessary as the Mediation SDK will set the consent status automatically based on the latest consent info.
+    @objc public static func setCCPAStatusOverride(_ status: Bool) {
+        isCCPAStatusOverriden = true
+        VunglePrivacySettings.setCCPAStatus(status)
+        os_log(.info, log: log, "Vungle SDK CCPA status override set to %{public}s", "\(status)")
+    }
+
+    /// Internal flag that indicates if the GDPR status has been overriden by the publisher.
+    static private(set) var isGDPRStatusOverriden = false
+
+    /// Internal flag that indicates if the CCPA status has been overriden by the publisher.
+    static private(set) var isCCPAStatusOverriden = false
+
+    private static let log = OSLog(subsystem: "com.chartboost.mediation.adapter.vungle", category: "Configuration")
 }

--- a/Source/VungleAdapterInterstitialAd.swift
+++ b/Source/VungleAdapterInterstitialAd.swift
@@ -16,11 +16,15 @@ final class VungleAdapterInterstitialAd: VungleAdapterAd, PartnerAd {
     /// The partner ad view to display inline. E.g. a banner view.
     /// Should be nil for full-screen ads.
     var inlineView: UIView? { nil }
-        
+
+    /// The loaded partner ad banner size.
+    /// Should be `nil` for full-screen ads.
+    var bannerSize: PartnerBannerSize? { nil }
+
     /// Loads an ad.
     /// - parameter viewController: The view controller on which the ad will be presented on. Needed on load for some banners.
     /// - parameter completion: Closure to be performed once the ad has been loaded.
-    func load(with viewController: UIViewController?, completion: @escaping (Result<PartnerEventDetails, Error>) -> Void) {
+    func load(with viewController: UIViewController?, completion: @escaping (Result<PartnerDetails, Error>) -> Void) {
         log(.loadStarted)
         
         loadCompletion = completion
@@ -36,7 +40,7 @@ final class VungleAdapterInterstitialAd: VungleAdapterAd, PartnerAd {
     /// It will never get called for banner ads. You may leave the implementation blank for that ad format.
     /// - parameter viewController: The view controller on which the ad will be presented on.
     /// - parameter completion: Closure to be performed once the ad has been shown.
-    func show(with viewController: UIViewController, completion: @escaping (Result<PartnerEventDetails, Error>) -> Void) {
+    func show(with viewController: UIViewController, completion: @escaping (Result<PartnerDetails, Error>) -> Void) {
         log(.showStarted)
 
         guard let ad = self.ad else {

--- a/Source/VungleAdapterInterstitialAd.swift
+++ b/Source/VungleAdapterInterstitialAd.swift
@@ -8,18 +8,10 @@ import Foundation
 import VungleAdsSDK
 
 /// Chartboost Mediation Vungle adapter fullscreen ad.
-final class VungleAdapterInterstitialAd: VungleAdapterAd, PartnerAd {
+final class VungleAdapterInterstitialAd: VungleAdapterAd, PartnerFullscreenAd {
 
     /// Holds a refernce to the Vungle ad between the time load() exits and the delegate is called
     private var ad: VungleInterstitial?
-    
-    /// The partner ad view to display inline. E.g. a banner view.
-    /// Should be nil for full-screen ads.
-    var inlineView: UIView? { nil }
-
-    /// The loaded partner ad banner size.
-    /// Should be `nil` for full-screen ads.
-    var bannerSize: PartnerBannerSize? { nil }
 
     /// Loads an ad.
     /// - parameter viewController: The view controller on which the ad will be presented on. Needed on load for some banners.
@@ -37,7 +29,7 @@ final class VungleAdapterInterstitialAd: VungleAdapterAd, PartnerAd {
     }
     
     /// Shows a loaded ad.
-    /// It will never get called for banner ads. You may leave the implementation blank for that ad format.
+    /// Chartboost Mediation SDK will always call this method from the main thread.
     /// - parameter viewController: The view controller on which the ad will be presented on.
     /// - parameter completion: Closure to be performed once the ad has been shown.
     func show(with viewController: UIViewController, completion: @escaping (Result<PartnerDetails, Error>) -> Void) {

--- a/Source/VungleAdapterRewardedAd.swift
+++ b/Source/VungleAdapterRewardedAd.swift
@@ -17,10 +17,14 @@ final class VungleAdapterRewardedAd: VungleAdapterAd, PartnerAd {
     /// Should be nil for full-screen ads.
     var inlineView: UIView? { nil }
 
+    /// The loaded partner ad banner size.
+    /// Should be `nil` for full-screen ads.
+    var bannerSize: PartnerBannerSize? { nil }
+
     /// Loads an ad.
     /// - parameter viewController: The view controller on which the ad will be presented on. Needed on load for some banners.
     /// - parameter completion: Closure to be performed once the ad has been loaded.
-    func load(with viewController: UIViewController?, completion: @escaping (Result<PartnerEventDetails, Error>) -> Void) {
+    func load(with viewController: UIViewController?, completion: @escaping (Result<PartnerDetails, Error>) -> Void) {
         log(.loadStarted)
 
         loadCompletion = completion
@@ -36,7 +40,7 @@ final class VungleAdapterRewardedAd: VungleAdapterAd, PartnerAd {
     /// It will never get called for banner ads. You may leave the implementation blank for that ad format.
     /// - parameter viewController: The view controller on which the ad will be presented on.
     /// - parameter completion: Closure to be performed once the ad has been shown.
-    func show(with viewController: UIViewController, completion: @escaping (Result<PartnerEventDetails, Error>) -> Void) {
+    func show(with viewController: UIViewController, completion: @escaping (Result<PartnerDetails, Error>) -> Void) {
         log(.showStarted)
 
         guard let ad = self.ad else {

--- a/Source/VungleAdapterRewardedAd.swift
+++ b/Source/VungleAdapterRewardedAd.swift
@@ -8,18 +8,10 @@ import Foundation
 import VungleAdsSDK
 
 /// Chartboost Mediation Vungle adapter fullscreen ad.
-final class VungleAdapterRewardedAd: VungleAdapterAd, PartnerAd {
+final class VungleAdapterRewardedAd: VungleAdapterAd, PartnerFullscreenAd {
 
     /// Holds a refernce to the Vungle ad between the time load() exits and the delegate is called
     private var ad: VungleRewarded?
-
-    /// The partner ad view to display inline. E.g. a banner view.
-    /// Should be nil for full-screen ads.
-    var inlineView: UIView? { nil }
-
-    /// The loaded partner ad banner size.
-    /// Should be `nil` for full-screen ads.
-    var bannerSize: PartnerBannerSize? { nil }
 
     /// Loads an ad.
     /// - parameter viewController: The view controller on which the ad will be presented on. Needed on load for some banners.
@@ -37,7 +29,7 @@ final class VungleAdapterRewardedAd: VungleAdapterAd, PartnerAd {
     }
 
     /// Shows a loaded ad.
-    /// It will never get called for banner ads. You may leave the implementation blank for that ad format.
+    /// Chartboost Mediation SDK will always call this method from the main thread.
     /// - parameter viewController: The view controller on which the ad will be presented on.
     /// - parameter completion: Closure to be performed once the ad has been shown.
     func show(with viewController: UIViewController, completion: @escaping (Result<PartnerDetails, Error>) -> Void) {


### PR DESCRIPTION
Many adapters have similar code for finding the largest standard banner size that will fit within requested dimensions. This can now be replaced with BannerSize.largestStandardFixedSizeThatFits(in:)